### PR TITLE
Only call close on a non nil db

### DIFF
--- a/world/leveldb.go
+++ b/world/leveldb.go
@@ -36,7 +36,9 @@ func OpenWorld(path string) (World, error) {
 
 	world.db, err = leveldb.OpenFile(dbPath, nil)
 	if err != nil {
-		_ = world.db.Close()
+		if world.db != nil {
+			_ = world.db.Close()
+		}
 		return world, err
 	}
 	return world, nil


### PR DESCRIPTION
If Minecraft is open and logged into the world that leveldb is trying to access, a *fs.PathError is returned and `db` is nil. Calling Close() on the nil DB causes a panic.